### PR TITLE
Add Youtube Url To Video

### DIFF
--- a/app/auth/projects/[project_id]/page.tsx
+++ b/app/auth/projects/[project_id]/page.tsx
@@ -90,12 +90,18 @@ function Videos({
 
   function publishVideo(video: IVideo) {
     if (video) {
+      let youtubeUrl = prompt('Enter youtube url of the published video');
+
+      // Ensure that youtube url is provided
+      if (youtubeUrl === null || youtubeUrl === '') return;
+
       updateVideo({
         id: video.id,
         name: video.name,
         data: {
           ...video,
           isPublished: true,
+          youtubeUrl: youtubeUrl
         },
       });
     }
@@ -183,7 +189,12 @@ function Videos({
         return (
           <div className={'pl-4'}>
             {item.isPublished && (
-              <CheckmarkCircle24Filled className={'text-green-700'} />
+              <>
+                <a href={item.youtubeUrl} target='_blank'>
+                  Video Link
+                </a>
+                <CheckmarkCircle24Filled className={'text-green-700'} />
+              </>
             )}
           </div>
         );

--- a/src/types/video.types.ts
+++ b/src/types/video.types.ts
@@ -128,6 +128,7 @@ export interface IVideo {
   generatedVideoInfo?: IGeneratedVideoInfo[];
   id: string;
   isPublished?: boolean;
+  youtubeUrl?: string;
   name: string;
   overlay?: string;
   projectId?: string;


### PR DESCRIPTION
**Issue**: [#14](https://github.com/naveedshahzad/videoapp_issues/issues/14)

### Changes:
- Required user to give youtube url (or url of video of any other platform) when marking a video published.