### PR TITLE
Add Confirmation Before Deleting Scenes Or Video

### DIFF
--- a/app/auth/projects/[project_id]/page.tsx
+++ b/app/auth/projects/[project_id]/page.tsx
@@ -147,7 +147,9 @@ function Videos({
   }
 
   function deleteVideo(video: IVideo) {
-    deleteMutation.mutate(video.id);
+    if (confirm('Are you sure to delete the video?')) {
+      deleteMutation.mutate(video.id);
+    }
   }
 
   function createNewVideo(data: Partial<IVideo>) {

--- a/components/Scene/Scene.tsx
+++ b/components/Scene/Scene.tsx
@@ -65,11 +65,13 @@ export const Scene = (props: ISceneProps) => {
   };
 
   const deleteScene = () => {
-    deleteMutation.mutate({
-      id: props.videoId,
-      sceneId: props.sceneDocId,
-      sceneArrayIndex: props.sceneArrayIndex,
-    });
+    if (confirm('Are you sure to delete this scene?')) {
+      deleteMutation.mutate({
+        id: props.videoId,
+        sceneId: props.sceneDocId,
+        sceneArrayIndex: props.sceneArrayIndex,
+      });
+    }
   };
 
   const onAudioEnd = () => {


### PR DESCRIPTION
**Issue:** [#5](https://github.com/naveedshahzad/videoapp_issues/issues/5#event-15898079840)

### Changes:
- Added simple confirmation from user before performing delete action on video and scenes.