### PR TITLE
Video creation error dialog 

### DIFF
--- a/app/auth/projects/[project_id]/page.tsx
+++ b/app/auth/projects/[project_id]/page.tsx
@@ -41,7 +41,7 @@ import {
   MoreVertical20Regular,
   Settings32Filled,
 } from '@fluentui/react-icons';
-import { LanguageDialog } from '@/components/Dialog/Dialog';
+import { LanguageDialog } from '@/components/LanguageDialog/LanguageDialog';
 import { VideoClient } from '@/src/apis/video.client';
 import { formatDate, generatePreviewUrl } from '@/src/helpers';
 import { FormAddVideo } from '@/components/FormAddVideo';

--- a/app/auth/videos/page.tsx
+++ b/app/auth/videos/page.tsx
@@ -32,7 +32,7 @@ import { IVideo } from '@/src/types/video.types';
 import { useQueryClient } from '@tanstack/react-query';
 import { useMyToastController } from '@/components/MyToast/MyToast.hook';
 import { MoreVertical20Regular } from '@fluentui/react-icons';
-import { LanguageDialog } from '@/components/Dialog/Dialog';
+import { LanguageDialog } from '@/components/LanguageDialog/LanguageDialog';
 import { VideoClient } from '@/src/apis/video.client';
 import { generatePreviewUrl } from '@/src/helpers';
 

--- a/components/Dialog/Dialog.tsx
+++ b/components/Dialog/Dialog.tsx
@@ -1,62 +1,54 @@
-"use client";
-import * as React from "react";
+import * as React from 'react';
 import {
+  Button,
   Dialog,
+  DialogActions,
+  DialogBody,
+  DialogContent,
   DialogSurface,
   DialogTitle,
-  DialogBody,
-  DialogActions,
-  Button,
-  Dropdown,
-  Option,
-  OptionOnSelectData,
-  SelectionEvents,
-} from "@fluentui/react-components";
-import { SUPPORTED_LANGUAGES } from "@/src/constants";
+} from '@fluentui/react-components';
 
-interface LanguageDialogProps {
+interface DialogProps {
   open: boolean;
+  title: string;
+  children: React.ReactNode;
   onClose: () => void;
-  onSubmit: (language: string) => void;
+  onSubmit?: () => void;
+  submitButtonText?: string;
+  closeButtonText?: string;
 }
 
-export const LanguageDialog: React.FC<LanguageDialogProps> = ({
+export const ReusableDialog: React.FC<DialogProps> = ({
   open,
+  title,
+  children,
   onClose,
   onSubmit,
+  submitButtonText = 'Submit',
+  closeButtonText = 'Close',
 }) => {
-  const [language, setLanguage] = React.useState<string>("");
-
-  const handleChange = (event: SelectionEvents, data: OptionOnSelectData) => {
-    setLanguage(data.optionValue as string);
-  };
-
   return (
     <Dialog open={open}>
       <DialogSurface>
         <DialogBody>
-          <DialogTitle>Select Language</DialogTitle>
-          <Dropdown
-            positioning={"below"}
-            placeholder="Select an option"
-            onOptionSelect={handleChange}
-          >
-            {Object.entries(SUPPORTED_LANGUAGES).map(([key, value]) => (
-              <Option key={key} value={value.value}>
-                {value.label}
-              </Option>
-            ))}
-          </Dropdown>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogContent>{children}</DialogContent>
+
           <DialogActions>
             <Button appearance="secondary" onClick={onClose}>
-              Close
+              {closeButtonText}
             </Button>
-            <Button appearance="primary" onClick={() => onSubmit(language)}>
-              Submit
-            </Button>
+            {onSubmit && (
+              <Button appearance="primary" onClick={onSubmit}>
+                {submitButtonText}
+              </Button>
+            )}
           </DialogActions>
         </DialogBody>
       </DialogSurface>
     </Dialog>
   );
 };
+
+export default ReusableDialog;

--- a/components/Dialog/index.ts
+++ b/components/Dialog/index.ts
@@ -1,0 +1,1 @@
+export * from './Dialog';

--- a/components/Image/Image.tsx
+++ b/components/Image/Image.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { SyntheticEvent, useState } from 'react';
 import { InsertImageModal } from '@/components/InsertImageModal/InsertImageModal';
 import { IInsertImageProps } from '@/components/InsertImage/InsertImage';
 import { ArrowSync24Filled } from '@fluentui/react-icons';
@@ -11,6 +11,7 @@ export function Image({
   isViewOnly,
   onUploadSuccess,
   onDelete,
+  onError,
   src,
   isCopyable,
   copyPosition,
@@ -25,6 +26,10 @@ export function Image({
     onUploadSuccess && onUploadSuccess(url);
   };
 
+  const onImageError = (e: SyntheticEvent<HTMLImageElement, Event>) => {
+    onError && onError('Image not found');
+  };
+
   return (
     // TODO: This component can be improved by adding a loading state when uploading an image.
     // TODO: className relative can be moved to the parent div
@@ -35,11 +40,11 @@ export function Image({
             <CopyIcon position={copyPosition || 'top-right'} copyText={src} />
           )}
           {onDelete && <DeleteIcon onClick={onDelete} />}
-          <img src={src} />
+          <img src={src} onError={onImageError} />
         </div>
       ) : (
         <div className={`relative`}>
-          <img src={src} />
+          <img src={src} onError={onImageError} />
           {isCopyable && <CopyIcon position={'top-right'} copyText={src} />}
           {!isViewOnly && (
             // Replace button at right top
@@ -77,6 +82,7 @@ export interface IImageProps extends Partial<IInsertImageProps> {
   onDelete?: () => void;
   isAIImage?: boolean;
   alt?: string;
+  onError?: (error: string) => void;
 }
 
 export default Image;

--- a/components/LanguageDialog/LanguageDialog.tsx
+++ b/components/LanguageDialog/LanguageDialog.tsx
@@ -1,0 +1,62 @@
+"use client";
+import * as React from "react";
+import {
+  Dialog,
+  DialogSurface,
+  DialogTitle,
+  DialogBody,
+  DialogActions,
+  Button,
+  Dropdown,
+  Option,
+  OptionOnSelectData,
+  SelectionEvents,
+} from "@fluentui/react-components";
+import { SUPPORTED_LANGUAGES } from "@/src/constants";
+
+interface LanguageDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (language: string) => void;
+}
+
+export const LanguageDialog: React.FC<LanguageDialogProps> = ({
+  open,
+  onClose,
+  onSubmit,
+}) => {
+  const [language, setLanguage] = React.useState<string>("");
+
+  const handleChange = (event: SelectionEvents, data: OptionOnSelectData) => {
+    setLanguage(data.optionValue as string);
+  };
+
+  return (
+    <Dialog open={open}>
+      <DialogSurface>
+        <DialogBody>
+          <DialogTitle>Select Language</DialogTitle>
+          <Dropdown
+            positioning={"below"}
+            placeholder="Select an option"
+            onOptionSelect={handleChange}
+          >
+            {Object.entries(SUPPORTED_LANGUAGES).map(([key, value]) => (
+              <Option key={key} value={value.value}>
+                {value.label}
+              </Option>
+            ))}
+          </Dropdown>
+          <DialogActions>
+            <Button appearance="secondary" onClick={onClose}>
+              Close
+            </Button>
+            <Button appearance="primary" onClick={() => onSubmit(language)}>
+              Submit
+            </Button>
+          </DialogActions>
+        </DialogBody>
+      </DialogSurface>
+    </Dialog>
+  );
+};

--- a/components/RenderLayoutComponent/RenderLayoutComponent.tsx
+++ b/components/RenderLayoutComponent/RenderLayoutComponent.tsx
@@ -8,6 +8,7 @@ export default function RenderLayoutComponent({
   layoutId,
   sceneId,
   content,
+  onError,
   parentEl,
   isDisplayNone = false,
 }: IRenderLayoutComponentProps) {
@@ -37,6 +38,7 @@ export default function RenderLayoutComponent({
           sceneId={sceneId}
           parentEl={parentEl}
           ref={ref}
+          onError={onError}
         />
       )}
     </div>
@@ -47,4 +49,5 @@ export interface IRenderLayoutComponentProps extends ILayoutProps {
   layoutId: string;
   isDisplayNone?: boolean;
   parentEl?: HTMLElement | null;
+  onError?: (error: string) => void;
 }

--- a/components/Scene/Scene.tsx
+++ b/components/Scene/Scene.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { ChangeEvent, useRef, useState } from 'react';
+import { ChangeEvent, useEffect, useRef, useState } from 'react';
 import { debounce } from 'lodash';
 import { Spinner, Textarea } from '@fluentui/react-components';
 import {
@@ -22,7 +22,11 @@ import { useVideoStore } from '@/src/stores/video.store';
 let mutateDebounce: any = undefined;
 export const Scene = (props: ISceneProps) => {
   const setSceneDesc = useVideoStore((state) => state.setSceneDesc);
-
+  const descRef = useRef<HTMLTextAreaElement>(null);
+  const [isHover, setIsHover] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const [errors, setErrors] = useState<string[]>([]);
+  const [sceneCSSClasses, setSceneCSSClasses] = useState('');
   const { mutate: updateScene } = useMutationUpdateScene();
   const {
     mutate: postTextToSpeech,
@@ -30,10 +34,6 @@ export const Scene = (props: ISceneProps) => {
     isPending,
   } = useMutationPostTextToSpeech();
   const deleteMutation = useMutationDeleteScene();
-
-  const descRef = useRef<HTMLTextAreaElement>(null);
-  const [isHover, setIsHover] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
 
   const onHover = () => {
     setIsHover(true);
@@ -90,6 +90,23 @@ export const Scene = (props: ISceneProps) => {
     console.log('Audio ended');
   };
 
+  useEffect(() => {
+    if (errors.length) {
+      setSceneCSSClasses(
+        `border-2 ${
+          props.isSelected
+            ? 'border-red-500'
+            : ' border-red-300 hover:border-red-500'
+        } `,
+      );
+    } else {
+      setSceneCSSClasses(
+        `border-2  ${
+          props.isSelected ? 'border-violet-500' : 'hover:border-violet-300'
+        } `,
+      );
+    }
+  }, [props.isSelected, errors]);
   return (
     <div
       onMouseEnter={onHover}
@@ -118,11 +135,7 @@ export const Scene = (props: ISceneProps) => {
       </div>
       {/*Scene body start*/}
       <div
-        className={`m-1 flex cursor-pointer flex-col border-r-2 p-2 pr-0 ${
-          props.isSelected
-            ? 'border-2 border-violet-500'
-            : 'border-2 border-violet-50 hover:border-violet-300'
-        }`}
+        className={`m-1 flex cursor-pointer flex-col border-r-2 p-2 pr-0 ${sceneCSSClasses}`}
         id={props.id}
         onClick={() =>
           props.onClick &&
@@ -135,13 +148,19 @@ export const Scene = (props: ISceneProps) => {
           )
         }
       >
-        <div className={'flex'}>
-          <div style={{ width: '220px' }} ref={ref}>
+        <div className={`flex`}>
+          <div
+            style={{
+              width: '220px',
+            }}
+            ref={ref}
+          >
             <RenderLayoutComponent
               layoutId={props.layoutId}
               sceneId={props.sceneDocId}
               content={props.content}
               parentEl={ref?.current}
+              onError={(error) => setErrors([...errors, error])}
             />
           </div>
 

--- a/components/Scene/Scene.tsx
+++ b/components/Scene/Scene.tsx
@@ -106,6 +106,7 @@ export const Scene = (props: ISceneProps) => {
         } `,
       );
     }
+    props.onErrors && props.onErrors(errors);
   }, [props.isSelected, errors]);
   return (
     <div
@@ -243,6 +244,7 @@ export interface ISceneProps extends IScene {
   onDrop: (e: React.DragEvent<HTMLDivElement>) => void;
   onDragOver: (e: React.DragEvent<HTMLDivElement>) => void;
   onCreateScene: (addAfter: boolean, sceneArrayIndex?: number) => void;
+  onErrors: (errors: string[]) => void;
 }
 
 export default Scene;

--- a/components/SceneList/SceneList.tsx
+++ b/components/SceneList/SceneList.tsx
@@ -19,10 +19,7 @@ import { CreateSceneWithTextModal } from '@/components/CreateSceneWithTextModal'
 
 export function SceneList(props: ISceneListProps) {
   const params = useParams();
-  const setSelectedContent = useVideoStore((state) => state.setSceneContent);
-  const setSceneDesc = useVideoStore((state) => state.setSceneDesc);
-  const selectedSceneId = useVideoStore((state) => state.selectedSceneId);
-  const setSelectedSceneId = useVideoStore((state) => state.setSelectedSceneId);
+
   const [markerIndex, setMarkerIndex] = useState<number | undefined>(undefined);
   const [scenes, setScenes] = useState<IScene[]>(props.scenes);
   const [draggedSceneIndex, setDraggedSceneIndex] = useState<
@@ -30,6 +27,14 @@ export function SceneList(props: ISceneListProps) {
   >(undefined);
   const [isSceneWithTextModalOpen, setIsSceneWithTextModalOpen] =
     useState<boolean>(false);
+
+  const setSelectedContent = useVideoStore((state) => state.setSceneContent);
+  const setSceneDesc = useVideoStore((state) => state.setSceneDesc);
+  const selectedSceneId = useVideoStore((state) => state.selectedSceneId);
+  const setSelectedSceneId = useVideoStore((state) => state.setSelectedSceneId);
+  const setVideoErrors = useVideoStore((state) => state.setVideoErrors);
+  const videoErrors = useVideoStore((state) => state.videoErrors);
+
   const onSceneChange = (
     sceneId: string,
     layoutId: string,
@@ -74,6 +79,11 @@ export function SceneList(props: ISceneListProps) {
     newScenes.splice(newSceneArrayIndex, 0, scene);
     setScenes(newScenes);
   };
+
+  const onError = (error: string[]) => {
+    setVideoErrors && setVideoErrors(error);
+  };
+
   useEffect(() => {
     setScenes(props.scenes);
   }, [props.scenes]);
@@ -96,6 +106,12 @@ export function SceneList(props: ISceneListProps) {
     }
   }, [selectedSceneId]);
 
+  useEffect(() => {
+    return () => {
+      setVideoErrors && setVideoErrors([]);
+    };
+  }, []);
+
   return (
     <div className="flex- flex max-h-screen flex-col items-center overflow-auto pb-10 pt-10">
       <div className="flex flex-col">
@@ -116,6 +132,7 @@ export function SceneList(props: ISceneListProps) {
             layoutId={scene.layoutId || DEFAULT_LAYOUT.id}
             isSelected={scene.id === selectedSceneId}
             onCreateScene={props.createScene}
+            onErrors={onError}
           />
         ))}
       </div>

--- a/components/Video/Video.tsx
+++ b/components/Video/Video.tsx
@@ -1,7 +1,7 @@
 import CopyIcon, { ICopyIconProps } from '@/components/CopyIcon/CopyIcon';
 import { IInsertImageProps } from '@/components/InsertImage/InsertImage';
 import { ArrowSync24Filled } from '@fluentui/react-icons';
-import { useState } from 'react';
+import { SyntheticEvent, useState } from 'react';
 import InsertImageModal from '@/components/InsertImageModal/InsertImageModal';
 import DeleteIcon from '@/components/DeleteIcon/DeleteIcon';
 
@@ -12,6 +12,7 @@ export function Video({
   isViewOnly,
   onUploadSuccess,
   onDelete,
+  onError,
 }: IVideoProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const onSuccessfulUpload = (url: string) => {
@@ -19,10 +20,13 @@ export function Video({
     onUploadSuccess && onUploadSuccess(url);
   };
 
+  const onVideoError = (e: SyntheticEvent<HTMLVideoElement, Event>) => {
+    onError && onError('Video not found');
+  };
   return (
     <>
       <div className={'relative'}>
-        <video controls src={src} />
+        <video controls src={src} onError={onVideoError} />
         {isCopyable && (
           <CopyIcon position={copyPosition || 'top-right'} copyText={src} />
         )}
@@ -56,4 +60,5 @@ export interface IVideoProps extends Partial<IInsertImageProps> {
   isCopyable?: boolean;
   copyPosition?: ICopyIconProps['position'];
   onDelete?: () => void;
+  onError?: (error: string) => void;
 }

--- a/components/layouts/Layout5.tsx
+++ b/components/layouts/Layout5.tsx
@@ -5,13 +5,17 @@ import Image from '@/components/Image/Image';
 import { Title1 } from '@fluentui/react-components';
 
 export const Layout5 = forwardRef<HTMLImageElement, ILayoutProps>(
-  ({ content, sceneId, isDisplayNone, isViewOnly }: ILayoutProps, ref) => {
+  (
+    { content, sceneId, isDisplayNone, isViewOnly, onError }: ILayoutProps,
+    ref,
+  ) => {
     return (
       <LayoutBody isNone={isDisplayNone} ref={ref} sceneId={sceneId}>
         <Image
           src={content?.image?.value as string}
           isCopyable={true}
           isViewOnly={isViewOnly}
+          onError={onError}
         />
         <div
           className={' absolute flex h-full w-full items-center justify-center'}

--- a/components/layouts/Layout6.tsx
+++ b/components/layouts/Layout6.tsx
@@ -6,7 +6,14 @@ import useResizeFont from '@/hooks/useResizeFont';
 
 export const Layout6 = forwardRef<HTMLImageElement, ILayoutProps>(
   (
-    { content, sceneId, isDisplayNone, isViewOnly, parentEl }: ILayoutProps,
+    {
+      content,
+      sceneId,
+      isDisplayNone,
+      isViewOnly,
+      parentEl,
+      onError,
+    }: ILayoutProps,
     ref,
   ) => {
     const fontSize = useResizeFont(parentEl);
@@ -16,6 +23,7 @@ export const Layout6 = forwardRef<HTMLImageElement, ILayoutProps>(
           src={content?.video?.value as string}
           isCopyable={true}
           isViewOnly={isViewOnly}
+          onError={onError}
         />
         <div
           className={' absolute flex h-full w-full items-center justify-center'}

--- a/components/layouts/LayoutImage.tsx
+++ b/components/layouts/LayoutImage.tsx
@@ -4,7 +4,10 @@ import LayoutBody from '@/components/layouts/LayoutBody';
 import Image from '@/components/Image/Image';
 
 export const LayoutImage = forwardRef<HTMLImageElement, ILayoutProps>(
-  ({ content, sceneId, isDisplayNone, isViewOnly }: ILayoutProps, ref) => {
+  (
+    { content, sceneId, isDisplayNone, isViewOnly, onError }: ILayoutProps,
+    ref,
+  ) => {
     return (
       <LayoutBody isNone={isDisplayNone} ref={ref} sceneId={sceneId}>
         <Image
@@ -12,6 +15,7 @@ export const LayoutImage = forwardRef<HTMLImageElement, ILayoutProps>(
           isViewOnly={isViewOnly}
           isCopyable={true}
           isAIImage={true}
+          onError={onError}
         />
       </LayoutBody>
     );

--- a/components/layouts/LayoutVideo.tsx
+++ b/components/layouts/LayoutVideo.tsx
@@ -4,13 +4,17 @@ import LayoutBody from '@/components/layouts/LayoutBody';
 import { Video } from '@/components/Video/Video';
 
 export const LayoutVideo = forwardRef<HTMLImageElement, ILayoutProps>(
-  ({ content, sceneId, isDisplayNone, isViewOnly }: ILayoutProps, ref) => {
+  (
+    { content, sceneId, isDisplayNone, isViewOnly, onError }: ILayoutProps,
+    ref,
+  ) => {
     return (
       <LayoutBody isNone={isDisplayNone} ref={ref} sceneId={sceneId}>
         <Video
           src={content?.video?.value as string}
           isCopyable={true}
           isViewOnly={isViewOnly}
+          onError={onError}
         />
       </LayoutBody>
     );

--- a/components/layouts/types.ts
+++ b/components/layouts/types.ts
@@ -6,4 +6,5 @@ export interface ILayoutProps {
   isViewOnly?: boolean;
   content?: Record<string, IInput>;
   parentEl?: HTMLElement | null;
+  onError?: (error: string) => void;
 }

--- a/src/stores/video.store.ts
+++ b/src/stores/video.store.ts
@@ -51,5 +51,11 @@ export const useVideoStore = create<IVideoStore>()(
         sceneDesc: desc,
       }));
     },
+    setVideoErrors: (errors) => {
+      set((state) => ({
+        ...state,
+        videoErrors: errors,
+      }));
+    },
   })),
 );

--- a/src/types/video.types.ts
+++ b/src/types/video.types.ts
@@ -10,6 +10,8 @@ export interface IVideoStore {
   setMessage: (message: IMessage) => void;
   removeMessage: (id: string) => void;
   currentProjectId?: string;
+  videoErrors?: string[];
+  setVideoErrors?: (errors: string[]) => void;
   setSceneContent: (
     layoutId: string,
     sceneId: string,


### PR DESCRIPTION
This pull request includes several updates and improvements across multiple files, focusing on refactoring dialog components, handling errors in images and scenes, and updating imports. The most important changes include the creation of a reusable dialog component, error handling for images and scenes, and updating the import paths for dialog components.

### Dialog Component Refactoring:
* [`components/Dialog/Dialog.tsx`](diffhunk://#diff-2eb04bb614fd5f68c401694c2ec720e6d2dc1ca6d45711c740a1fd666bfe2e5fL1-R54): Refactored the `LanguageDialog` to a more generic `ReusableDialog` component, allowing for flexible titles, children, and button texts.
* [`components/Dialog/index.ts`](diffhunk://#diff-f8e7382eb58fcf25f340e15ecb1e5df357ef25a6a6c8fba87e0a380af91142cfR1): Exported the new `ReusableDialog` component.
* [`components/LanguageDialog/LanguageDialog.tsx`](diffhunk://#diff-b2b7de8b16f2f06cddb3a45cc419760ae70863b86537d1b61dfd2ac8b72e8033R1-R62): Added a new `LanguageDialog` component separate from the reusable dialog.

### Error Handling:
* [`components/Image/Image.tsx`](diffhunk://#diff-56e991c9863bff9c5403ec8b5573d5573ae3d86aa8de5cebe79b146b75eb24ccL1-R1): Added an `onError` prop to handle image load errors and updated the `Image` component to use this prop. [[1]](diffhunk://#diff-56e991c9863bff9c5403ec8b5573d5573ae3d86aa8de5cebe79b146b75eb24ccL1-R1) [[2]](diffhunk://#diff-56e991c9863bff9c5403ec8b5573d5573ae3d86aa8de5cebe79b146b75eb24ccR14) [[3]](diffhunk://#diff-56e991c9863bff9c5403ec8b5573d5573ae3d86aa8de5cebe79b146b75eb24ccR29-R32) [[4]](diffhunk://#diff-56e991c9863bff9c5403ec8b5573d5573ae3d86aa8de5cebe79b146b75eb24ccL38-R47) [[5]](diffhunk://#diff-56e991c9863bff9c5403ec8b5573d5573ae3d86aa8de5cebe79b146b75eb24ccR85)
* [`components/Scene/Scene.tsx`](diffhunk://#diff-eb52e881cc408c5d8896691f59fb3a8d3f7daadcb4086d142edf5eeb2e97ca21L2-R2): Added error handling for scenes, including visual indicators for errors and an `onErrors` prop to propagate errors. [[1]](diffhunk://#diff-eb52e881cc408c5d8896691f59fb3a8d3f7daadcb4086d142edf5eeb2e97ca21L2-R2) [[2]](diffhunk://#diff-eb52e881cc408c5d8896691f59fb3a8d3f7daadcb4086d142edf5eeb2e97ca21L25-R29) [[3]](diffhunk://#diff-eb52e881cc408c5d8896691f59fb3a8d3f7daadcb4086d142edf5eeb2e97ca21L34-L37) [[4]](diffhunk://#diff-eb52e881cc408c5d8896691f59fb3a8d3f7daadcb4086d142edf5eeb2e97ca21R93-R110) [[5]](diffhunk://#diff-eb52e881cc408c5d8896691f59fb3a8d3f7daadcb4086d142edf5eeb2e97ca21L121-R139) [[6]](diffhunk://#diff-eb52e881cc408c5d8896691f59fb3a8d3f7daadcb4086d142edf5eeb2e97ca21L138-R164) [[7]](diffhunk://#diff-eb52e881cc408c5d8896691f59fb3a8d3f7daadcb4086d142edf5eeb2e97ca21R247)
* [`components/RenderLayoutComponent/RenderLayoutComponent.tsx`](diffhunk://#diff-49d95d53d4504c8d5ff7febcaaa36baa1a28c9056ff14a88f81b4314a49bec14R11): Added an `onError` prop for handling errors in layout rendering. [[1]](diffhunk://#diff-49d95d53d4504c8d5ff7febcaaa36baa1a28c9056ff14a88f81b4314a49bec14R11) [[2]](diffhunk://#diff-49d95d53d4504c8d5ff7febcaaa36baa1a28c9056ff14a88f81b4314a49bec14R41) [[3]](diffhunk://#diff-49d95d53d4504c8d5ff7febcaaa36baa1a28c9056ff14a88f81b4314a49bec14R52)

### Import Path Updates:
* `app/auth/projects/[project_id]/page.tsx`, `app/auth/videos/page.tsx`: Updated import paths for `LanguageDialog` to reflect its new location. ([app/auth/projects/[project_id]/page.tsxL44-R44](diffhunk://#diff-d828de810a8bdbdae8e32e4bd81ac1a1e3ebfdc2e4d07fc39e51aba5acc01d09L44-R44), [app/auth/videos/page.tsxL35-R35](diffhunk://#diff-472b099fd5d5bd25df8fb88d237ffb7703123ea8a33809a49cd085a340f4997fL35-R35))
* `app/auth/projects/[project_id]/video/[video_id]/page.tsx`: Updated import paths and added `ReusableDialog` import. ([app/auth/projects/[project_id]/video/[video_id]/page.tsxR48](diffhunk://#diff-e738f5bf6ed86f86c2a7d2b21545569bbcfe33cbb97c6994716029702e7bf1e1R48))

### Additional Changes:
* `app/auth/projects/[project_id]/video/[video_id]/page.tsx`: Introduced state management for error dialogs and hover states. ([app/auth/projects/[project_id]/video/[video_id]/page.tsxL58-R59](diffhunk://#diff-e738f5bf6ed86f86c2a7d2b21545569bbcfe33cbb97c6994716029702e7bf1e1L58-R59), [app/auth/projects/[project_id]/video/[video_id]/page.tsxR72-R76](diffhunk://#diff-e738f5bf6ed86f86c2a7d2b21545569bbcfe33cbb97c6994716029702e7bf1e1R72-R76), [app/auth/projects/[project_id]/video/[video_id]/page.tsxL119-L120](diffhunk://#diff-e738f5bf6ed86f86c2a7d2b21545569bbcfe33cbb97c6994716029702e7bf1e1L119-L120), [app/auth/projects/[project_id]/video/[video_id]/page.tsxR205-R209](diffhunk://#diff-e738f5bf6ed86f86c2a7d2b21545569bbcfe33cbb97c6994716029702e7bf1e1R205-R209), [app/auth/projects/[project_id]/video/[video_id]/page.tsxR295-R308](diffhunk://#diff-e738f5bf6ed86f86c2a7d2b21545569bbcfe33cbb97c6994716029702e7bf1e1R295-R308))
* [`components/SceneList/SceneList.tsx`](diffhunk://#diff-3c86f75e0c3acdaec4efbeb8237260ec9f7e56c162929ff56bfd1376709b6864L22-R37): Managed video errors state and ensured errors are reset when the component unmounts. [[1]](diffhunk://#diff-3c86f75e0c3acdaec4efbeb8237260ec9f7e56c162929ff56bfd1376709b6864L22-R37) [[2]](diffhunk://#diff-3c86f75e0c3acdaec4efbeb8237260ec9f7e56c162929ff56bfd1376709b6864R82-R86) [[3]](diffhunk://#diff-3c86f75e0c3acdaec4efbeb8237260ec9f7e56c162929ff56bfd1376709b6864R109-R114)