### PR TITLE
Fix Add Project Button Bug

### DIFF
--- a/app/auth/projects/page.tsx
+++ b/app/auth/projects/page.tsx
@@ -150,6 +150,7 @@ const Projects: FC = () => {
             <Button
               appearance={'primary'}
               onClick={() => {
+                setCurrentProject(null);
                 setIsOpen(true);
               }}
             >


### PR DESCRIPTION
**Issue:** https://github.com/naveedshahzad/videoapp_issues/issues/69

### Changes Description:
- `currentProject` state is set to `null` on click on `Add Project` button to ensure the side panel opens up in **add mode.**