### PR TITLE
Show Error Toast When Runner Server Isn't Selected

### DIFF
--- a/app/auth/projects/[project_id]/settings/page.tsx
+++ b/app/auth/projects/[project_id]/settings/page.tsx
@@ -454,6 +454,9 @@ function Page({
               <h5>
                 This server name is required to select runner on batch server.
               </h5>
+              {!data?.runnerServerName && (
+                <h5 style={{ color: 'red' }}>*This field is required</h5>
+              )}
               <Select
                 onChange={(
                   ev: ChangeEvent<HTMLSelectElement>,

--- a/app/auth/projects/[project_id]/video/[video_id]/page.tsx
+++ b/app/auth/projects/[project_id]/video/[video_id]/page.tsx
@@ -215,6 +215,11 @@ export default function Page({
       console.warn(
         'Runner server setting not available, check your project settings',
       );
+      dispatchToast({
+        title: 'Runner Server Not Selected',
+        body: 'Please select runner server from `Project Settings > General Tab > Select Runner Server`',
+        intent: 'error',
+      });
       return;
     }
     // Update video status to in_progress


### PR DESCRIPTION
**Issue:** #104 

### Changes Description:
- Display an error toast when the user clicks on **Create Video** without selecting a runner server in project settings.
- On the Settings page, show the message "This field is required" when the runner server selection is left empty to provide clear user feedback.