### PR TITLE
Adjust Font Size Of Title On Preview Of Layout 6

### DIFF
--- a/components/layouts/Layout6.tsx
+++ b/components/layouts/Layout6.tsx
@@ -20,7 +20,12 @@ export const Layout6 = forwardRef<HTMLImageElement, ILayoutProps>(
     }: ILayoutProps,
     ref,
   ) => {
-    const fontSize = useResizeFont(parentEl);
+    const fontSize = useResizeFont(parentEl, {
+      small: '5rem',
+      medium: '10rem',
+      large: '15rem',
+    });
+
     return (
       <LayoutBody isNone={isDisplayNone} ref={ref} sceneId={sceneId}>
         <Video

--- a/components/layouts/Layout6.tsx
+++ b/components/layouts/Layout6.tsx
@@ -39,7 +39,7 @@ export const Layout6 = forwardRef<HTMLImageElement, ILayoutProps>(
           className={' absolute flex h-full w-full items-center justify-center'}
         >
           <div
-            style={{ fontSize: fontSize }}
+            style={{ fontSize: fontSize, lineHeight: 1.4}}
             className={'align-center p-2 text-white'}
           >
             {content?.title?.value}


### PR DESCRIPTION
**Issue:** https://github.com/naveedshahzad/videoapp_issues/issues/68

### Problem Root Cause:
- The `LayoutBody` component scaled down the `Video` component and the title div.
- For this reason the fontsize of 1rem applied by the `useResizeFont` hook was also scaled down by `0.1667` making it appear as `2.56px` (`0.1667 × 16`) text which is very hard to see.

### Current Fix:
- Custom breakpoints are provided to `useResizeFont` hook to ensure the text looks big enough when scaled down.

### Other Possible Fixes (Opinion):
- Instead of hardcoding title's font size, we can provide a slider to adjust font size.
- The color of title text can be made changeable to ensure it can be seen on light/white backgrounds.

**NOTE:** The custom breakpoints that I used can be adjusted further based on testing and/or feedback.